### PR TITLE
Parse current conditions response data into current conditions models

### DIFF
--- a/weatheroyce.xcodeproj/project.pbxproj
+++ b/weatheroyce.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3AED141820A4C4C40046079A /* weatheroyceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AED141720A4C4C40046079A /* weatheroyceTests.swift */; };
 		3AED142720A4CB850046079A /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AED142620A4CB850046079A /* WeatherService.swift */; };
 		3AED142920A4D18C0046079A /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AED142820A4D18C0046079A /* NetworkManager.swift */; };
+		3AED142D20A4DD1E0046079A /* CurrentWeatherConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AED142C20A4DD1E0046079A /* CurrentWeatherConditions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +41,7 @@
 		3AED141920A4C4C40046079A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3AED142620A4CB850046079A /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		3AED142820A4D18C0046079A /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		3AED142C20A4DD1E0046079A /* CurrentWeatherConditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentWeatherConditions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +90,7 @@
 				3AED140E20A4C4C30046079A /* Info.plist */,
 				3AED142B20A4D19E0046079A /* Services */,
 				3AED142A20A4D1910046079A /* Managers */,
+				3AED142E20A4DD220046079A /* Models */,
 			);
 			path = weatheroyce;
 			sourceTree = "<group>";
@@ -148,6 +151,14 @@
 				3AED142620A4CB850046079A /* WeatherService.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		3AED142E20A4DD220046079A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3AED142C20A4DD1E0046079A /* CurrentWeatherConditions.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -253,6 +264,7 @@
 			files = (
 				3AED142920A4D18C0046079A /* NetworkManager.swift in Sources */,
 				3AED140520A4C4C20046079A /* CurrentWeatherCondiditions.swift in Sources */,
+				3AED142D20A4DD1E0046079A /* CurrentWeatherConditions.swift in Sources */,
 				3AED142720A4CB850046079A /* WeatherService.swift in Sources */,
 				3AED140320A4C4C20046079A /* AppDelegate.swift in Sources */,
 			);

--- a/weatheroyce/Managers/NetworkManager.swift
+++ b/weatheroyce/Managers/NetworkManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class NetworkManager {
     
-    class func getDataFor(_ url: URL, completion: (Data) -> Void) {
+    class func getDataFor(_ url: URL, completion: @escaping (Data) -> Void) {
         
         let session = URLSession(configuration: .default)
         let request = URLRequest(url: url)
@@ -18,12 +18,16 @@ class NetworkManager {
         session.dataTask(with: request) { (data, response, error) in
             //do something with the data
             guard error == nil else {
-                print("error from Network Manager: \(error)")
+                print("error from Network Manager: \(String(describing: error))")
                 return
             }
             
-            let json = String(data: data!, encoding: .utf8)
-            print(json)
+            guard let responseData = data else {
+                print("did not have responseData")
+                return
+            }
+            
+            completion(responseData)
             
             }.resume()
         

--- a/weatheroyce/Models/CurrentWeatherConditions.swift
+++ b/weatheroyce/Models/CurrentWeatherConditions.swift
@@ -1,0 +1,9 @@
+//
+//  CurrentWeatherConditions.swift
+//  weatheroyce
+//
+//  Created by George Royce on 5/10/18.
+//  Copyright © 2018 George Royce. All rights reserved.
+//
+
+import Foundation

--- a/weatheroyce/Models/CurrentWeatherConditions.swift
+++ b/weatheroyce/Models/CurrentWeatherConditions.swift
@@ -7,3 +7,19 @@
 //
 
 import Foundation
+
+struct CurrentWeatherConditions {
+    
+    let degreesFahrenheit: Int
+    
+    init(_ raw: RawCurrentWeatherConditions) {
+        degreesFahrenheit = Int(raw.temp_f)
+    }
+    
+}
+
+struct RawCurrentWeatherConditions: Decodable {
+    
+    let temp_f: Float
+    
+}

--- a/weatheroyce/Services/WeatherService.swift
+++ b/weatheroyce/Services/WeatherService.swift
@@ -26,12 +26,25 @@ class WeatherService {
         }
         
         NetworkManager.getDataFor(url) { (responseData) in
+            do {
+                let rawIntermediateConditions = try JSONDecoder().decode(RawIntermediateCurrentConditionsInfo.self, from: responseData)
+                let rawCurrentConditions = rawIntermediateConditions.current_observation
+                let currentConditions = CurrentWeatherConditions(rawCurrentConditions)
+                print(currentConditions.degreesFahrenheit)
+            } catch {
+                print("error parsing data: \(error)")
+            }
             
         }
-        
     }
+}
+
+private struct RawIntermediateCurrentConditionsInfo: Decodable {
+    
+    let current_observation: RawCurrentWeatherConditions
     
 }
+
 
 
 


### PR DESCRIPTION
We used `Decodable` to help parse response data into models, taking the approach of creating raw objects so we don't need to manually map response keys into our own properties. 

The intermediary struct `RawIntermediateCurrentConditionsInfo` helps parse layers we're not using so we don't need to do anything beyond what we get for free with Decodable. No manual initializers was the main reason for this choice. 